### PR TITLE
Install linuxbrew using git

### DIFF
--- a/linuxbrew-core/Dockerfile
+++ b/linuxbrew-core/Dockerfile
@@ -1,14 +1,18 @@
 FROM ubuntu
 MAINTAINER Shaun Jackman <sjackman@gmail.com>
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get update
-RUN apt-get install -y curl g++ gawk m4 make patch ruby tcl
+RUN apt-get install -qq curl g++ gawk m4 make patch ruby tcl git
 
 RUN useradd -m linuxbrew
 RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
 USER linuxbrew
-WORKDIR /home/linuxbrew
-ENV PATH /home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
-RUN yes |ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/linuxbrew/go/install)"
+ENV unset LD_LIBRARY_PATH HOMEBREW_CC
+ENV prefix /home/linuxbrew/linuxbrew
+ENV PATH $prefix/bin:$prefix/sbin:$PATH
+
+RUN git clone https://github.com/Homebrew/linuxbrew.git $prefix
 RUN brew doctor || true


### PR DESCRIPTION
I might be doing it wrong, but using the original gave me this error:

```
This script will install:
//.linuxbrew/bin/brew
//.linuxbrew/Library/...
//.linuxbrew/share/man/man1/brew.1
/bin/mkdir: cannot create directory '//.linuxbrew': Permission denied
Failed during: /bin/mkdir -p //.linuxbrew
```

The rationale to change the strategy however is independent of that: it makes it more compatible to the standalone installation. See

```
$ cd linuxbrew-standalone
$ sudo docker build .
Step 0 : FROM sjackman/linuxbrew-core
 ---> d958b3aa4991
Step 1 : MAINTAINER Shaun Jackman <sjackman@gmail.com>
 ---> Using cache
 ---> 8346190e5ce0
Step 2 : USER root
 ---> Using cache
 ---> c8340433854f
Step 3 : RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64
 ---> Using cache
 ---> 9713b63bb2b4
Step 4 : USER linuxbrew
 ---> Using cache
 ---> 71a1624d3d7a
Step 5 : RUN mkdir $HOME/.linuxbrew/lib && ln -s lib $HOME/.linuxbrew/lib64
 ---> Running in 3edc3a433fbc
mkdir: cannot create directory '//.linuxbrew/lib': No such file or director
```

`$HOME` needs to be explicitly defined right? Or am I doing something really wrong?
If this looks good, I will update the `standalone` dockerfile too.

Also see @jmchilton's https://github.com/jmchilton/linuxbrew-docker-trials/issues/1
