### PR TITLE
Set $SHELL variable for brew install --debug

### DIFF
--- a/linuxbrew-core/Dockerfile
+++ b/linuxbrew-core/Dockerfile
@@ -4,11 +4,12 @@ MAINTAINER Shaun Jackman <sjackman@gmail.com>
 RUN apt-get update
 RUN apt-get install -y curl g++ gawk m4 make patch ruby tcl
 
-RUN useradd -m linuxbrew
+RUN useradd -m -s /bin/bash linuxbrew
 RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
 USER linuxbrew
 WORKDIR /home/linuxbrew
 ENV PATH /home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
+ENV SHELL /bin/bash
 RUN yes |ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/linuxbrew/go/install)"
 RUN brew doctor || true


### PR DESCRIPTION
When trying to open a shell while running `brew install --debug` one encounters quite cryptic error:

> /home/linuxbrew/.linuxbrew/Library/Homebrew/utils.rb:91:in `exec': can't convert nil into String (TypeError)
>   from /home/linuxbrew/.linuxbrew/Library/Homebrew/utils.rb:91:in `block in interactive_shell'
>   from /home/linuxbrew/.linuxbrew/Library/Homebrew/utils.rb:91:in `fork'
>   from /home/linuxbrew/.linuxbrew/Library/Homebrew/utils.rb:91:in `interactive_shell'
>  (...)

That's beacuse utils.rb tries to `exec` contents of ENV[SHELL] variable without checking it first. Since SHELL is not set in the Docker container debugging is quite complicated.

This patch attempts to fix said behaviour.
